### PR TITLE
Reduce Image Sizes with link to full image

### DIFF
--- a/blog_admin.py
+++ b/blog_admin.py
@@ -391,13 +391,14 @@ def replace_internal_links(html_str: str) -> str:
     # Return new HTML string
     return html_str
 
+
 def get_resize_arg(caption: str) -> Optional[str]:
     """Given an image caption, return the resizing argument passed to convert if an
     image size was given."""
     # Regular expressions to match different patterns
-    width_pattern = r'\|(\d+)$'
-    height_pattern = r'\|x(\d+)$'
-    dimensions_pattern = r'\|(\d+)x(\d+)$'
+    width_pattern = r"\|(\d+)$"
+    height_pattern = r"\|x(\d+)$"
+    dimensions_pattern = r"\|(\d+)x(\d+)$"
 
     # Check for width only
     match = re.search(width_pattern, caption)
@@ -420,7 +421,10 @@ def get_resize_arg(caption: str) -> Optional[str]:
     # If no pattern matches, return None
     return None
 
-def resize_image(source_path: str | os.PathLike, resize_arg: str, quality: float = 0.8) -> Optional[Path]:
+
+def resize_image(
+    source_path: str | os.PathLike, resize_arg: str, quality: float = 0.8
+) -> Optional[Path]:
     """Resize an image using ImageMagick convert.
 
     Arguments
@@ -434,15 +438,29 @@ def resize_image(source_path: str | os.PathLike, resize_arg: str, quality: float
     Path to reduced-size image.
     """
     source_path = Path(source_path).resolve()
-    if source_path.stem in [".svg", ".mp4", ".gif"]: # Don't try this on svg, mp4, or gif
+    if source_path.stem in [
+        ".svg",
+        ".mp4",
+        ".gif",
+    ]:  # Don't try this on svg, mp4, or gif
         return None
 
     out_path = source_path.parent / Path(source_path.stem + "_reduced.jpg")
-    cmd = ["convert", source_path, "-resize", resize_arg, "-quality", str(int(quality*100)), "-strip", str(out_path)]
+    cmd = [
+        "convert",
+        source_path,
+        "-resize",
+        resize_arg,
+        "-quality",
+        str(int(quality * 100)),
+        "-strip",
+        str(out_path),
+    ]
     print(f"Running {cmd}")
     subprocess.run(cmd, check=True)
 
     return out_path
+
 
 def generate_link_href(link: tuple[str, str]) -> str:
     return f"<a href='/blog/{link[0]}'>{link[1]}</a>"
@@ -500,27 +518,29 @@ def get_handle(title_str: str, max_length: int = 32) -> str:
 def remove_image_sizing_from_captions(html: str) -> str:
     """
     Removes any image sizing information from <figcaption> tags in HTML.
-    
+
     Arguments
     ---------
     html: The HTML string to process.
-    
+
     Returns
     -------
     The HTML string with image sizing information removed from <figcaption> tags.
     """
-    
+
     # Regular expression pattern to match <figcaption> tags and their content
-    figcaption_pattern = r'<figcaption>(.*?)</figcaption>'
-    
+    figcaption_pattern = r"<figcaption>(.*?)</figcaption>"
+
     def remove_sizing(match):
         # Remove the '|' and everything after it from the matched text
         caption = match.group(1).split("|")[0]
         return f"<figcaption>{caption}</figcaption>"
-    
+
     # Replace the matched <figcaption> tags with the new content
     cleaned_html = re.sub(figcaption_pattern, remove_sizing, html)
-    
+
     return cleaned_html
+
+
 if __name__ == "__main__":
     cli()

--- a/blog_admin.py
+++ b/blog_admin.py
@@ -81,6 +81,7 @@ def make_post(markdown_file: Optional[str] = None) -> Post:
     title, content = parse_markdown(markdown_file)
     content = replace_image_sources(content)
     content = replace_internal_links(content)
+    content = remove_image_sizing_from_captions(content)
     content = add_autoplay(content)
     handle = get_handle(title)
     with app.app_context():
@@ -496,5 +497,30 @@ def get_handle(title_str: str, max_length: int = 32) -> str:
     return "_".join(words[0:last_index]).lower()
 
 
+def remove_image_sizing_from_captions(html: str) -> str:
+    """
+    Removes any image sizing information from <figcaption> tags in HTML.
+    
+    Arguments
+    ---------
+    html: The HTML string to process.
+    
+    Returns
+    -------
+    The HTML string with image sizing information removed from <figcaption> tags.
+    """
+    
+    # Regular expression pattern to match <figcaption> tags and their content
+    figcaption_pattern = r'<figcaption>(.*?)</figcaption>'
+    
+    def remove_sizing(match):
+        # Remove the '|' and everything after it from the matched text
+        caption = match.group(1).split("|")[0]
+        return f"<figcaption>{caption}</figcaption>"
+    
+    # Replace the matched <figcaption> tags with the new content
+    cleaned_html = re.sub(figcaption_pattern, remove_sizing, html)
+    
+    return cleaned_html
 if __name__ == "__main__":
     cli()

--- a/blog_admin.py
+++ b/blog_admin.py
@@ -377,6 +377,40 @@ def replace_internal_links(html_str: str) -> str:
     # Return new HTML string
     return html_str
 
+def get_resize_arg(caption: str) -> Optional[str]:
+    """Given an image caption, return the resizing argument passed to convert if an
+    image size was given."""
+    # Regular expressions to match different patterns
+    width_pattern = r'\|(\d+)$'
+    height_pattern = r'\|x(\d+)$'
+    dimensions_pattern = r'\|(\d+)x(\d+)$'
+
+    # Check for width only
+    match = re.search(width_pattern, caption)
+    if match:
+        width = match.group(1)
+        return f"{width}x>"
+
+    # Check for height only
+    match = re.search(height_pattern, caption)
+    if match:
+        height = match.group(1)
+        return f"x{height}>"
+
+    # Check for both width and height
+    match = re.search(dimensions_pattern, caption)
+    if match:
+        width, height = match.groups()
+        return f"{width}x{height}"
+
+    # If no pattern matches, return None
+    return None
+
+def resize_image(source_path: str | os.PathLike, resize_arg: str):
+    # TODO: parse the source path and append `_small` to the end
+    out_path = "out.jpg"
+    cmd = ["convert", source_path, "-resize", resize_arg, out_path]
+    subprocess.run(cmd, check=True)
 
 def generate_link_href(link: tuple[str, str]) -> str:
     return f"<a href='/blog/{link[0]}'>{link[1]}</a>"

--- a/blog_admin.py
+++ b/blog_admin.py
@@ -79,6 +79,7 @@ def make_post(markdown_file: Optional[str] = None) -> Post:
         # fuzzy finder search
         markdown_file = copy_post()
     title, content = parse_markdown(markdown_file)
+    summary=content.split("\n")[1]
     content = replace_image_sources(content)
     content = replace_internal_links(content)
     content = remove_image_sizing_from_captions(content)
@@ -88,6 +89,7 @@ def make_post(markdown_file: Optional[str] = None) -> Post:
         new_post = Post(
             title=title,
             content=content,
+            summary=summary,
             handle=handle,
             visibility=Visibility.HIDDEN,
         )

--- a/test_admin.py
+++ b/test_admin.py
@@ -8,8 +8,28 @@ from blog_admin import (
     get_internal_links,
     parse_internal_link,
     replace_internal_links,
+    get_resize_arg,
 )
 
+@pytest.mark.parametrize("caption, expected_output", [
+    ("My Image |500", "500x>"),
+    ("My Image |x600", "x600>"),
+    ("My Image |640x480", "640x480"),
+    ("My Image", None),
+    ("My Image |invalid", None),
+    ("My Image |x", None),
+    ("My Image |x600x800", None),
+])
+def test_get_resize_arg(caption, expected_output):
+    """
+    Test the get_resize_arg function with various input captions.
+
+    Args:
+        caption (str): The input caption string.
+        expected_output (str or None): The expected output string or None.
+    """
+    output = get_resize_arg(caption)
+    assert output == expected_output
 
 @pytest.mark.parametrize(
     "html_string, video_tag",

--- a/test_admin.py
+++ b/test_admin.py
@@ -9,18 +9,22 @@ from blog_admin import (
     parse_internal_link,
     replace_internal_links,
     get_resize_arg,
-    remove_image_sizing_from_captions
+    remove_image_sizing_from_captions,
 )
 
-@pytest.mark.parametrize("caption, expected_output", [
-    ("My Image |500", "500x>"),
-    ("My Image |x600", "x600>"),
-    ("My Image |640x480", "640x480"),
-    ("My Image", None),
-    ("My Image |invalid", None),
-    ("My Image |x", None),
-    ("My Image |x600x800", None),
-])
+
+@pytest.mark.parametrize(
+    "caption, expected_output",
+    [
+        ("My Image |500", "500x>"),
+        ("My Image |x600", "x600>"),
+        ("My Image |640x480", "640x480"),
+        ("My Image", None),
+        ("My Image |invalid", None),
+        ("My Image |x", None),
+        ("My Image |x600x800", None),
+    ],
+)
 def test_get_resize_arg(caption, expected_output):
     """
     Test the get_resize_arg function with various input captions.
@@ -31,6 +35,7 @@ def test_get_resize_arg(caption, expected_output):
     """
     output = get_resize_arg(caption)
     assert output == expected_output
+
 
 @pytest.mark.parametrize(
     "html_string, video_tag",
@@ -156,22 +161,32 @@ def test_replace_internal_links(html_string, expected, monkeypatch):
 def test_link_href(link: tuple[str, str], expected: str):
     assert generate_link_href(link) == expected
 
-@pytest.mark.parametrize("html_input, expected_output", [
-    ("<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 |500</figcaption></figure></body></html>",
-     "<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 </figcaption></figure></body></html>"),
 
-    ("<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 |x600</figcaption></figure></body></html>",
-     "<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 </figcaption></figure></body></html>"),
-
-    ("<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 |640x480</figcaption></figure></body></html>",
-     "<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 </figcaption></figure></body></html>"),
-
-    ("<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>",
-     "<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>"),
-
-    ("<html><body><p>No figcaption here</p></body></html>",
-     "<html><body><p>No figcaption here</p></body></html>"),
-])
+@pytest.mark.parametrize(
+    "html_input, expected_output",
+    [
+        (
+            "<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 |500</figcaption></figure></body></html>",
+            "<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 </figcaption></figure></body></html>",
+        ),
+        (
+            "<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 |x600</figcaption></figure></body></html>",
+            "<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 </figcaption></figure></body></html>",
+        ),
+        (
+            "<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 |640x480</figcaption></figure></body></html>",
+            "<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 </figcaption></figure></body></html>",
+        ),
+        (
+            "<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>",
+            "<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>",
+        ),
+        (
+            "<html><body><p>No figcaption here</p></body></html>",
+            "<html><body><p>No figcaption here</p></body></html>",
+        ),
+    ],
+)
 def test_remove_image_sizing_from_captions(html_input, expected_output):
     """
     Test the remove_image_sizing_from_captions function with various input HTML strings.

--- a/test_admin.py
+++ b/test_admin.py
@@ -9,6 +9,7 @@ from blog_admin import (
     parse_internal_link,
     replace_internal_links,
     get_resize_arg,
+    remove_image_sizing_from_captions
 )
 
 @pytest.mark.parametrize("caption, expected_output", [
@@ -154,3 +155,30 @@ def test_replace_internal_links(html_string, expected, monkeypatch):
 )
 def test_link_href(link: tuple[str, str], expected: str):
     assert generate_link_href(link) == expected
+
+@pytest.mark.parametrize("html_input, expected_output", [
+    ("<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 |500</figcaption></figure></body></html>",
+     "<html><body><figure><img src='image1.jpg' alt='Image 1'><figcaption>Caption 1 </figcaption></figure></body></html>"),
+
+    ("<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 |x600</figcaption></figure></body></html>",
+     "<html><body><figure><img src='image2.jpg' alt='Image 2'><figcaption>Caption 2 </figcaption></figure></body></html>"),
+
+    ("<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 |640x480</figcaption></figure></body></html>",
+     "<html><body><figure><img src='image3.jpg' alt='Image 3'><figcaption>Caption 3 </figcaption></figure></body></html>"),
+
+    ("<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>",
+     "<html><body><figure><img src='image4.jpg' alt='Image 4'><figcaption>Caption 4</figcaption></figure></body></html>"),
+
+    ("<html><body><p>No figcaption here</p></body></html>",
+     "<html><body><p>No figcaption here</p></body></html>"),
+])
+def test_remove_image_sizing_from_captions(html_input, expected_output):
+    """
+    Test the remove_image_sizing_from_captions function with various input HTML strings.
+
+    Args:
+        html_input (str): The input HTML string.
+        expected_output (str): The expected output HTML string.
+    """
+    output = remove_image_sizing_from_captions(html_input)
+    assert output == expected_output


### PR DESCRIPTION
Closes #35. There is no option to forego the full-size image, recommend post authors
just reduce image on their own if that's what they want.
- **add function + test to get resize arg.**
- **implement copying and reducing size of images**
- **Remove image sizing markup from captions**
- **format: black**
- **add links for resized images to full-size**
- **fix: add summary when creating new posts**
